### PR TITLE
NLP-related improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - db
     environment:
       - PYTHONUNBUFFERED=1
+    restart: on-failure:5 
+
 
   frontend:
     build:

--- a/listener/grab_tweets.py
+++ b/listener/grab_tweets.py
@@ -56,10 +56,7 @@ class Listener(StreamListener):
 
 
 scottish_rugby_terms = [
-	"#AsOne",
-	"WarriorNation",
-	"#AlwaysEdinburgh"
-	"@scotlandteam",
+	"@Scotlandteam",
 	"@GlasgowWarriors",
 	"@EdinburghRugby"
 ]

--- a/listener/ipynb/Tweets from old games.ipynb
+++ b/listener/ipynb/Tweets from old games.ipynb
@@ -1,0 +1,281 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tweets from old games"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`scotrugbytweets` uses some rudimentary NLP-based named entity extraction from `nltk` with some fairly poor results. I've added a 'boring term' blacklist (team names, home nations, sponsors) but this is fairly unscalable and might miss out on some cool organic trends. In this notebook, I'll have a look at historical tweets around a Glasgow Warriors and Edinburgh Rugby game to get some insight into what is typically being tweeted about, and what might be interesting for `scotrugbytweets` visualisations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tweepy import OAuthHandler, Cursor, API\n",
+    "import yaml\n",
+    "\n",
+    "#add directory above to path (listener Python namespace)\n",
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "with open('../credentials.yaml', 'r') as f:\n",
+    "    creds = yaml.load(f)\n",
+    "    \n",
+    "auth = OAuthHandler(creds['consumer']['key'], creds['consumer']['secret'])\n",
+    "auth.set_access_token(creds['access']['key'], creds['access']['secret'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to the week-limit on the Twitter API, we can only grab historical tweets from two Scottish games.\n",
+    "\n",
+    "* **Glasgow Warriors** (A) v. Benetton Treviso (5/1/19 15:00KO)\n",
+    "* **Edinburgh** (H) v. Southern Kings (5/1/19 19:35 KO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "games_meta = {\n",
+    "    'GLA': {'kickoff': pd.to_datetime('2019-01-05 15:00'), \n",
+    "            'twitter_punc': ['@GlasgowWarriors', '#wearewarriors', '#warriornation'], \n",
+    "            'opposition': '@BenettonTreviso'},\n",
+    "    'EDI': {'kickoff': pd.to_datetime('2019-01-05 19:35'), \n",
+    "            'twitter_punc': ['@EdinburghRugby', '#alwaysedinburgh'], \n",
+    "            'opposition': '@SouthernKings'}\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['@GlasgowWarriors', '#wearewarriors', '#warriornation']"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "games_meta['GLA']['twitter_punc']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GLA\n",
+      "EDI\n"
+     ]
+    }
+   ],
+   "source": [
+    "import csv\n",
+    "from nlp import clean_tweet, extract_entities\n",
+    "from itertools import chain\n",
+    "\n",
+    "for team in games_meta.keys():\n",
+    "    print(team)\n",
+    "    csv_file = open('tweets_{0}.csv'.format(team), 'w')\n",
+    "    csv_writer = csv.writer(csv_file)\n",
+    "    \n",
+    "    #time definition\n",
+    "    window = '1 day'\n",
+    "    start_time = games_meta[team]['kickoff'] - pd.Timedelta(window)\n",
+    "    end_time = games_meta[team]['kickoff'] + pd.Timedelta(window)\n",
+    "\n",
+    "    api = API(auth)\n",
+    "    tweets = Cursor(api.search, q=games_meta[team]['twitter_punc'], lang=\"en\",\n",
+    "           since=start_time, until=end_time)\n",
+    "\n",
+    "    for tweet in tweets.items():\n",
+    "        cleaned_tweet = clean_tweet(tweet.text)\n",
+    "        print(cleaned_tweet)\n",
+    "        csv_writer.writerow([tweet.created_at, cleaned_tweet, extract_entities(cleaned_tweet)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'RT Just going to leave this here'"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cleaned_tweet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 280\r\n",
+      "-rw-r--r--  1 jjac  staff   7.9K  8 Jan 18:50 Tweets from old games.ipynb\r\n",
+      "-rw-r--r--  1 jjac  staff    81K  8 Jan 18:49 tweets.csv\r\n",
+      "-rw-r--r--  1 jjac  staff     0B  8 Jan 19:07 tweets_EDI.csv\r\n",
+      "-rw-r--r--  1 jjac  staff     0B  8 Jan 19:07 tweets_GLA.csv\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -lh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweets_df = pd.read_csv('./tweets.csv', header=None)\n",
+    "tweets_df.columns = ['timestamp', 'tweet', 'entities']\n",
+    "\n",
+    "tweets_df['entities'] = tweets_df['entities'].apply(lambda row: row[1:-1].split(', '))\n",
+    "entities = pd.Series([row[1:-1] for row in list(chain(*tweets_df['entities'].values))])\n",
+    "entities = entities[entities != ''] #filter empty results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Benetton         43\n",
+       "Italian          29\n",
+       "Conference       24\n",
+       "Treviso          17\n",
+       "Hastings         13\n",
+       "Sam Johnson      12\n",
+       "Rosie            10\n",
+       "Horne             8\n",
+       "Johnson           8\n",
+       "Europe            8\n",
+       "Rennie            8\n",
+       "SCRUM             7\n",
+       "Kick              7\n",
+       "Nairn             7\n",
+       "Dave Rennie       6\n",
+       "Dave              6\n",
+       "GLA               5\n",
+       "McDowall          5\n",
+       "Hogg              5\n",
+       "Jackson           5\n",
+       "Adam              5\n",
+       "Good              5\n",
+       "ESPN              5\n",
+       "Special Win       5\n",
+       "Kebble            5\n",
+       "Yep               4\n",
+       "Monigo            4\n",
+       "Click             4\n",
+       "Thomson           4\n",
+       "Capitano          4\n",
+       "                 ..\n",
+       "TRY               1\n",
+       "Narin             1\n",
+       "Poor              1\n",
+       "Dire              1\n",
+       "Didn              1\n",
+       "LOTR              1\n",
+       "GLASGOW           1\n",
+       "Strauss           1\n",
+       "Total             1\n",
+       "Xmas              1\n",
+       "Damp              1\n",
+       "Matthew Smith     1\n",
+       "Hmmm              1\n",
+       "Thank             1\n",
+       "Update            1\n",
+       "Keep              1\n",
+       "Possession        1\n",
+       "Fantastic         1\n",
+       "Irish             1\n",
+       "BBC               1\n",
+       "Nick Grigg        1\n",
+       "Please            1\n",
+       "Sweet             1\n",
+       "RUGBY             1\n",
+       "Jones             1\n",
+       "Dolce Vita        1\n",
+       "WARRIORS          1\n",
+       "Unfortunate       1\n",
+       "Correct           1\n",
+       "HAWICK            1\n",
+       "Length: 192, dtype: int64"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entities.value_counts()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/listener/ipynb/Tweets from old games.ipynb
+++ b/listener/ipynb/Tweets from old games.ipynb
@@ -47,43 +47,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 153,
    "metadata": {},
    "outputs": [],
    "source": [
     "games_meta = {\n",
     "    'GLA': {'kickoff': pd.to_datetime('2019-01-05 15:00'), \n",
-    "            'twitter_punc': ['@GlasgowWarriors', '#wearewarriors', '#warriornation'], \n",
+    "            'twitter_punc': ['@GlasgowWarriors'], \n",
     "            'opposition': '@BenettonTreviso'},\n",
     "    'EDI': {'kickoff': pd.to_datetime('2019-01-05 19:35'), \n",
-    "            'twitter_punc': ['@EdinburghRugby', '#alwaysedinburgh'], \n",
+    "            'twitter_punc': ['@EdinburghRugby'], \n",
     "            'opposition': '@SouthernKings'}\n",
-    "        }"
+    "        }\n",
+    "\n",
+    "def querify(hashtags):\n",
+    "    query = ' OR '.join(hashtags)\n",
+    "    return query"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['@GlasgowWarriors', '#wearewarriors', '#warriornation']"
-      ]
-     },
-     "execution_count": 74,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "games_meta['GLA']['twitter_punc']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [
     {
@@ -107,67 +91,25 @@
     "    \n",
     "    #time definition\n",
     "    window = '1 day'\n",
-    "    start_time = games_meta[team]['kickoff'] - pd.Timedelta(window)\n",
-    "    end_time = games_meta[team]['kickoff'] + pd.Timedelta(window)\n",
+    "    start_time = str(games_meta[team]['kickoff'] - pd.Timedelta(window)).split(' ')[0]\n",
+    "    end_time = str(games_meta[team]['kickoff'] + pd.Timedelta(window)).split(' ')[0]\n",
     "\n",
-    "    api = API(auth)\n",
-    "    tweets = Cursor(api.search, q=games_meta[team]['twitter_punc'], lang=\"en\",\n",
+    "    api = API(auth, wait_on_rate_limit=True)\n",
+    "    tweets = Cursor(api.search, q=querify(games_meta[team]['twitter_punc']), lang=\"en\",\n",
     "           since=start_time, until=end_time)\n",
     "\n",
     "    for tweet in tweets.items():\n",
     "        cleaned_tweet = clean_tweet(tweet.text)\n",
-    "        print(cleaned_tweet)\n",
     "        csv_writer.writerow([tweet.created_at, cleaned_tweet, extract_entities(cleaned_tweet)])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'RT Just going to leave this here'"
-      ]
-     },
-     "execution_count": 92,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cleaned_tweet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 89,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "total 280\r\n",
-      "-rw-r--r--  1 jjac  staff   7.9K  8 Jan 18:50 Tweets from old games.ipynb\r\n",
-      "-rw-r--r--  1 jjac  staff    81K  8 Jan 18:49 tweets.csv\r\n",
-      "-rw-r--r--  1 jjac  staff     0B  8 Jan 19:07 tweets_EDI.csv\r\n",
-      "-rw-r--r--  1 jjac  staff     0B  8 Jan 19:07 tweets_GLA.csv\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!ls -lh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "tweets_df = pd.read_csv('./tweets.csv', header=None)\n",
+    "tweets_df = pd.read_csv('./tweets_GLA.csv', header=None)\n",
     "tweets_df.columns = ['timestamp', 'tweet', 'entities']\n",
     "\n",
     "tweets_df['entities'] = tweets_df['entities'].apply(lambda row: row[1:-1].split(', '))\n",
@@ -177,77 +119,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Benetton         43\n",
-       "Italian          29\n",
-       "Conference       24\n",
-       "Treviso          17\n",
-       "Hastings         13\n",
-       "Sam Johnson      12\n",
-       "Rosie            10\n",
-       "Horne             8\n",
-       "Johnson           8\n",
-       "Europe            8\n",
-       "Rennie            8\n",
-       "SCRUM             7\n",
-       "Kick              7\n",
-       "Nairn             7\n",
-       "Dave Rennie       6\n",
-       "Dave              6\n",
-       "GLA               5\n",
-       "McDowall          5\n",
-       "Hogg              5\n",
-       "Jackson           5\n",
-       "Adam              5\n",
-       "Good              5\n",
-       "ESPN              5\n",
-       "Special Win       5\n",
-       "Kebble            5\n",
-       "Yep               4\n",
-       "Monigo            4\n",
-       "Click             4\n",
-       "Thomson           4\n",
-       "Capitano          4\n",
-       "                 ..\n",
-       "TRY               1\n",
-       "Narin             1\n",
-       "Poor              1\n",
-       "Dire              1\n",
-       "Didn              1\n",
-       "LOTR              1\n",
-       "GLASGOW           1\n",
-       "Strauss           1\n",
-       "Total             1\n",
-       "Xmas              1\n",
-       "Damp              1\n",
-       "Matthew Smith     1\n",
-       "Hmmm              1\n",
-       "Thank             1\n",
-       "Update            1\n",
-       "Keep              1\n",
-       "Possession        1\n",
-       "Fantastic         1\n",
-       "Irish             1\n",
-       "BBC               1\n",
-       "Nick Grigg        1\n",
-       "Please            1\n",
-       "Sweet             1\n",
-       "RUGBY             1\n",
-       "Jones             1\n",
-       "Dolce Vita        1\n",
-       "WARRIORS          1\n",
-       "Unfortunate       1\n",
-       "Correct           1\n",
-       "HAWICK            1\n",
-       "Length: 192, dtype: int64"
+       "BT                       94\n",
+       "TRY                      42\n",
+       "Great                    27\n",
+       "YOUR                     21\n",
+       "Big Bill                 20\n",
+       "GAME                     18\n",
+       "Hickey                   16\n",
+       "Fraser McKenzie          13\n",
+       "Darcy Graham             11\n",
+       "Fraz                     10\n",
+       "Try                      10\n",
+       "George Taylor            10\n",
+       "Darcy                    10\n",
+       "Simon                     9\n",
+       "Fowles                    9\n",
+       "Ross                      8\n",
+       "Cammy Fenton              8\n",
+       "MOTM                      8\n",
+       "Dougie Fife               8\n",
+       "Southern Kings            8\n",
+       "Ally Miller               8\n",
+       "Fife                      7\n",
+       "Simon Berghan             7\n",
+       "Ally                      7\n",
+       "Kings                     7\n",
+       "James                     7\n",
+       "Rory Sutherland           6\n",
+       "Charlie Shiel             6\n",
+       "Simon Hickey              6\n",
+       "Richard Cockerill         5\n",
+       "                         ..\n",
+       "Agreed                    1\n",
+       "First                     1\n",
+       "Charlie Shiels            1\n",
+       "Superb                    1\n",
+       "Wonder                    1\n",
+       "Merve                     1\n",
+       "V Southern Kings Come     1\n",
+       "Didn                      1\n",
+       "Europe                    1\n",
+       "Jesus                     1\n",
+       "Mission                   1\n",
+       "Bright                    1\n",
+       "Head Coach                1\n",
+       "Key                       1\n",
+       "Absolute                  1\n",
+       "Murray McCallum           1\n",
+       "Nice                      1\n",
+       "Fair                      1\n",
+       "Treviso                   1\n",
+       "HT                        1\n",
+       "Nathan Fowles             1\n",
+       "Year                      1\n",
+       "XXL                       1\n",
+       "BLACK                     1\n",
+       "Brilliant                 1\n",
+       "Yesss                     1\n",
+       "Shiel                     1\n",
+       "Clinical                  1\n",
+       "Pietro Ceccarelli         1\n",
+       "List                      1\n",
+       "Length: 162, dtype: int64"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/listener/nlp.py
+++ b/listener/nlp.py
@@ -3,7 +3,10 @@ from nltk.tree import Tree
 
 def clean_tweet(tweet):
 	twitter_punc = ['#', '@']
-	terms_to_remove = ['Edinburgh', 'Glasgow', 'Scotstoun', 'Murrayfield', 'Scotland']
+	terms_to_remove = ['Edinburgh', 'Glasgow', 'Scotstoun', 
+        'Murrayfield', 'Scotland', 'Warrior',
+        'England', 'Wales', 'Italy', 'France',
+        'Ireland', 'Pro14', 'Guinness']
 	filter_list = twitter_punc + terms_to_remove
 
 	filtered = [word for word in tweet.split() if not any(punc in word for punc in filter_list)]


### PR DESCRIPTION
**Unrelated (infra) changes:**
* `listener` now has restart policy (tweepy seems to fail a lot)

**NLP changes**
* Increased blacklist of 'boring' terms (home nations, Guinness, Pro14)
* Reduced filtered terms on stream to team Twitter handles. Hashtags too noisy from other sports, teams


